### PR TITLE
Type cast before normalize detr

### DIFF
--- a/tests/models/detr/test_feature_extraction_detr.py
+++ b/tests/models/detr/test_feature_extraction_detr.py
@@ -20,6 +20,7 @@ import unittest
 
 import numpy as np
 
+from parameterized import parameterized
 from transformers.testing_utils import require_torch, require_vision, slow
 from transformers.utils import is_torch_available, is_vision_available
 
@@ -336,3 +337,43 @@ class DetrFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestC
         # verify size
         expected_size = torch.tensor([800, 1066])
         assert torch.allclose(encoding["labels"][0]["size"], expected_size)
+
+    @parameterized.expand(
+        [
+            ("do_resize_True_do_normalize_True_pad_True", True, True, True),
+            ("do_resize_True_do_normalize_False_pad_True", True, False, True),
+            ("do_resize_False_do_normalize_False_pad_True", False, False, True),
+            ("do_resize_False_do_normalize_True_pad_True", False, True, True),
+            ("do_resize_True_do_normalize_True_pad_False", True, True, False),
+            ("do_resize_True_do_normalize_False_pad_False", True, False, False),
+            ("do_resize_False_do_normalize_False_pad_False", False, False, False),
+            ("do_resize_False_do_normalize_True_pad_False", False, True, False),
+        ]
+    )
+    def test_call_flags(self, _, do_resize, do_normalize, pad):
+        # Initialize feature_extractor
+        feature_extractor = self.feature_extraction_class(**self.feat_extract_dict)
+        feature_extractor.do_resize = do_resize
+        feature_extractor.do_normalize = do_normalize
+        # create random PIL images
+        image_inputs = prepare_image_inputs(self.feature_extract_tester, equal_resolution=False)
+
+        expected_shapes = [(3, *x.size[::-1]) for x in image_inputs]
+        if do_resize:
+            expected_shapes = [
+                (
+                    self.feature_extract_tester.num_channels,
+                    *self.feature_extract_tester.get_expected_values([image], batched=False),
+                )
+                for image in image_inputs
+            ]
+        if pad:
+            expected_shapes = [tuple(max(x) for x in zip(*expected_shapes))] * len(image_inputs)
+
+        pixel_values = feature_extractor(image_inputs, pad_and_return_pixel_mask=pad, return_tensors=None)[
+            "pixel_values"
+        ]
+        self.assertEqual(len(pixel_values), self.feature_extract_tester.batch_size)
+        for idx, image in enumerate(pixel_values):
+            self.assertEqual(image.shape, expected_shapes[idx])
+            self.assertIsInstance(image, np.ndarray)


### PR DESCRIPTION
# What does this PR do?

Modifies the feature extractor call to make the inputs to `BatchFeature` always numpy arrays. This ensures the type of the returned `pixel_values` matches those requested with `return_tensors`. The conversion to numpy arrays happens before normalization to ensure consistent rescaling is done on the inputs. 

This solution means the `return_tensors=None` default can stay and that the behaviour is as expected for any combination of the `do_xxx` flag values.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
