### PR TITLE
Type cast before normalize beit

### DIFF
--- a/src/transformers/models/beit/feature_extraction_beit.py
+++ b/src/transformers/models/beit/feature_extraction_beit.py
@@ -120,13 +120,15 @@ class BeitFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
             segmentation_maps (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `List[PIL.Image.Image]`, `List[np.ndarray]`, `List[torch.Tensor]`, *optional*):
                 Optionally, the corresponding semantic segmentation maps with the pixel-wise annotations.
 
-            return_tensors (`str` or [`~utils.TensorType`], *optional*, defaults to `'np'`):
-                If set, will return tensors of a particular framework. Acceptable values are:
+            return_tensors (`str` or [`~utils.TensorType`], *optional*, defaults to `None`):
+                If set, will return a tensor of a particular framework.
 
-                - `'tf'`: Return TensorFlow `tf.constant` objects.
-                - `'pt'`: Return PyTorch `torch.Tensor` objects.
-                - `'np'`: Return NumPy `np.ndarray` objects.
-                - `'jax'`: Return JAX `jnp.ndarray` objects.
+                Acceptable values are:
+                - `'tf'`: Return TensorFlow `tf.constant` object.
+                - `'pt'`: Return PyTorch `torch.Tensor` object.
+                - `'np'`: Return NumPy `np.ndarray` object.
+                - `'jax'`: Return JAX `jnp.ndarray` object.
+                - None: Return list of `np.ndarray` objects.
 
         Returns:
             [`BatchFeature`]: A [`BatchFeature`] with the following fields:
@@ -204,8 +206,15 @@ class BeitFeatureExtractor(FeatureExtractionMixin, ImageFeatureExtractionMixin):
             images = [self.center_crop(image, self.crop_size) for image in images]
             if segmentation_maps is not None:
                 segmentation_maps = [self.center_crop(map, size=self.crop_size) for map in segmentation_maps]
+
+        # if do_normalize=False, the casting to a numpy array won't happen, so we need to do it here
+        make_channel_first = True if isinstance(images[0], Image.Image) else images[0].shape[-1] in (1, 3)
+        images = [self.to_numpy_array(image, rescale=False, channel_first=make_channel_first) for image in images]
+
         if self.do_normalize:
-            images = [self.normalize(image=image, mean=self.image_mean, std=self.image_std) for image in images]
+            images = [
+                self.normalize(image=image, mean=self.image_mean, std=self.image_std, rescale=True) for image in images
+            ]
 
         # return as BatchFeature
         data = {"pixel_values": images}

--- a/tests/models/beit/test_feature_extraction_beit.py
+++ b/tests/models/beit/test_feature_extraction_beit.py
@@ -19,6 +19,7 @@ import unittest
 import numpy as np
 from datasets import load_dataset
 
+from parameterized import parameterized
 from transformers.testing_utils import require_torch, require_vision
 from transformers.utils import is_torch_available, is_vision_available
 
@@ -342,3 +343,50 @@ class BeitFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestC
         encoding = feature_extractor(image, map, return_tensors="pt")
         self.assertTrue(encoding["labels"].min().item() >= 0)
         self.assertTrue(encoding["labels"].max().item() <= 255)
+
+    @parameterized.expand(
+        [
+            ("do_resize_True_do_center_crop_True_do_normalize_True", True, True, True),
+            ("do_resize_True_do_center_crop_True_do_normalize_False", True, True, False),
+            ("do_resize_True_do_center_crop_False_do_normalize_True", True, False, True),
+            ("do_resize_True_do_center_crop_False_do_normalize_False", True, False, False),
+            ("do_resize_False_do_center_crop_True_do_normalize_True", False, True, True),
+            ("do_resize_False_do_center_crop_True_do_normalize_False", False, True, False),
+            ("do_resize_False_do_center_crop_False_do_normalize_True", False, False, True),
+            ("do_resize_False_do_center_crop_False_do_normalize_False", False, False, False),
+        ]
+    )
+    def test_call_flags(self, _, do_resize, do_center_crop, do_normalize):
+        # Initialize feature_extractor
+        feature_extractor = self.feature_extraction_class(**self.feat_extract_dict)
+        feature_extractor.do_center_crop = do_center_crop
+        feature_extractor.do_resize = do_resize
+        feature_extractor.do_normalize = do_normalize
+        # create random PIL images
+        image_inputs = prepare_image_inputs(self.feature_extract_tester, equal_resolution=False)
+
+        expected_shapes = [(3, *x.size[::-1]) for x in image_inputs]
+        if do_resize:
+            expected_shapes = [
+                (
+                    self.feature_extract_tester.num_channels,
+                    self.feature_extract_tester.size,
+                    self.feature_extract_tester.size,
+                )
+                for _ in range(self.feature_extract_tester.batch_size)
+            ]
+        if do_center_crop:
+            expected_shapes = [
+                (
+                    self.feature_extract_tester.num_channels,
+                    self.feature_extract_tester.crop_size,
+                    self.feature_extract_tester.crop_size,
+                )
+                for _ in range(self.feature_extract_tester.batch_size)
+            ]
+
+        pixel_values = feature_extractor(image_inputs, return_tensors=None)["pixel_values"]
+        self.assertEqual(len(pixel_values), self.feature_extract_tester.batch_size)
+        for idx, image in enumerate(pixel_values):
+            self.assertEqual(image.shape, expected_shapes[idx])
+            self.assertIsInstance(image, np.ndarray)


### PR DESCRIPTION
# What does this PR do?

Modifies the feature extractor call to make the inputs to `BatchFeature` always numpy arrays. This ensures the type of the returned `pixel_values` matches those requested with `return_tensors`. The conversion to numpy arrays happens before normalization to ensure consistent rescaling is done on the inputs. 

This solution means the `return_tensors=None` default can stay and that the behaviour is as expected for any combination of the `do_xxx` flag values.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
